### PR TITLE
boost write performance by 2x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,9 +3409,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -6763,6 +6763,8 @@ dependencies = [
  "dml",
  "generated_types",
  "hashbrown 0.14.0",
+ "lazy_static",
+ "libc",
  "mutable_batch",
  "mutable_batch_lp",
  "mutable_batch_pb",

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -11,6 +11,8 @@ crc32fast = "1.2.0"
 data_types = { path = "../data_types" }
 generated_types = { path = "../generated_types" }
 hashbrown.workspace = true
+lazy_static = "1.4.0"
+libc = "0.2.155"
 mutable_batch = { version = "0.1.0", path = "../mutable_batch" }
 mutable_batch_pb = { version = "0.1.0", path = "../mutable_batch_pb" }
 observability_deps = { path = "../observability_deps" }


### PR DESCRIPTION
## 优化效果
 
| benches |  优化前   |  优化后   |  提升  |
| :---- | :-----: | :-----: | --------: |
| single row write |  99.242 | 258.84  |  2.6x |
| batched 1000 row |  96.32 |  170.43 |  1.8x |

## 优化点
1. 在将数据写入 wal buffer 中时，用 tokio::watch 通知触发构造一个 write batch group. 之前是一个 10ms 的周期定时器触发。这样可以更加及时地将从 wal  buffer 中写入 wal，而且通过 channel 容量限制和写入文件所需要的时间，来实现 back pressure 的效果，达到一次性写入更多数据的效果。
2. 在文件写入时，使用 preallocation 和 sync_file_range/fsyncdata 来代替 fsync，达到更好的文件写入性能。

## 实验

运行  `cargo bench -p ingester  --features=benches --bench write`

以下是实验截图
<img width="517" alt="image" src="https://github.com/metrico/influxdb_iox/assets/5618388/e46ae844-a333-43d3-9ce6-d0dba4346fef">
<img width="672" alt="image" src="https://github.com/metrico/influxdb_iox/assets/5618388/e53b550a-fa86-4a77-94ee-f4a51d427166">
